### PR TITLE
Updates Dockerfile for Intel architecture

### DIFF
--- a/Dockerfile-intel
+++ b/Dockerfile-intel
@@ -18,8 +18,8 @@ COPY dist/ai_processing-0.0.0-cp311-cp311-linux_x86_64.whl /tmp/
 RUN pip install /tmp/ai_processing-0.0.0-cp311-cp311-linux_x86_64.whl
 
 # Install other Python dependencies
-COPY requirements.txt .
-RUN pip install -r requirements.txt
+COPY requirements-intel.txt .
+RUN pip install -r requirements-intel.txt
 
 WORKDIR /app
 EXPOSE 8000

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -24,6 +24,6 @@ else
     echo "Building default Docker image..."
     docker build -t ai-model-server .
 fi
-echo "Docker image built as ai-model-server`
+echo "Docker image built as ai-model-server"
 python migrate.py
 python server.py


### PR DESCRIPTION
Specifies `requirements-intel.txt` for installing dependencies in the Intel-specific Docker image build process.

Corrects a typo in the `install-linux.sh` script's echo message.