### PR TITLE
Fix preprocessing of transparent images.

### DIFF
--- a/lib/model/preprocessing_python/image_preprocessing.py
+++ b/lib/model/preprocessing_python/image_preprocessing.py
@@ -86,7 +86,10 @@ def preprocess_image(image_path, img_size=512, use_half_precision=True, device=N
             transforms.ToDtype(torch.float32, scale=True),
             transforms.Normalize(mean=mean, std=std),
         ])
-    return imageTransforms(read_image(image_path).to(device))
+    img = read_image(image_path).to(device)
+    if img.shape[0] == 4:
+        img = img[:3, :, :] # Drop alpha channel
+    return imageTransforms(img)
     
 
 #TODO: TRY OTHER PREPROCESSING METHODS AND TRY MAKING PREPROCESSING TRUE ASYNC


### PR DESCRIPTION
As it is currently, transparency causes a tensor size mismatch: The size of tensor a (4) must match the size of tensor b (3) at non-singleton dimension 0 for file: image.png

This simply drops the alpha channel if the image has one to prevent the error. 

Should also correctly fix issue #33 