### PR TITLE
Add log suppression for discarding framerate option

### DIFF
--- a/lib/model/preprocessing_python/image_preprocessing.py
+++ b/lib/model/preprocessing_python/image_preprocessing.py
@@ -29,6 +29,7 @@ except Exception:  # pragma: no cover - optional dependency
 _DEFFCODE_LOG_SUPPRESSIONS = (
     "Manually discarding `frame_format`",
     "Manually discarding `-size/-s`",
+    "Manually discarding `-framerate/-r`",
     "Manually disabling `-framerate/-r`",
     "No usable pixel-format defined. Switching to default",
     "Pipeline terminated successfully.",


### PR DESCRIPTION
Left suppression using `disabling` in case it could occur in other environments