### PR TITLE
Fix NVIDIA PyTorch audio wheel compatibility

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -1,6 +1,6 @@
 -r requirements-base.txt
 # Windows/Linux NVIDIA GPU requirements
---extra-index-url https://download.pytorch.org/whl/cu132
+--extra-index-url https://download.pytorch.org/whl/cu130
 torch==2.12.0
 torchvision==0.27.0
 torchaudio==2.11.0


### PR DESCRIPTION
The NVIDIA requirements previously used the CUDA 13.2 PyTorch wheel index with torch==2.12.0, torchvision==0.27.0, torchaudio==2.11.0, and torch-tensorrt==2.12.0.

That combination can install torch==2.12.0+cu132 and torchvision==0.27.0+cu132, but torchaudio==2.11.0 resolves to a CUDA 13.0 build. Importing torchaudio then fails at startup with PyTorch CUDA 13.2 versus TorchAudio CUDA 13.0.

Use the CUDA 13.0 wheel index instead. This keeps the same package version pins while resolving to a mutually compatible set: torch==2.12.0+cu130, torchvision==0.27.0+cu130, torchaudio==2.11.0+cu130, and torch-tensorrt==2.12.0+cu130.

Verified locally by importing torch, torchvision, and torchaudio together, importing lib.server.server_manager, and running uv pip check with all packages compatible.