### PR TITLE
Fixed compatibility with AMD Cards

### DIFF
--- a/install/requirements-amd.txt
+++ b/install/requirements-amd.txt
@@ -3,8 +3,8 @@ pillow
 # AMD GPU requirements (Linux with ROCm)
 --extra-index-url https://download.pytorch.org/whl/rocm7.2
 
-torch==2.12.0
-torchvision==0.27.0
-torchaudio==2.11.0
+torch==2.12.0+rocm7.2
+torchvision==0.27.0+rocm7.2
+torchaudio==2.11.0+rocm7.2
 
 # Common dependencies


### PR DESCRIPTION
Hello, 
this PR fixes issues with AMD Cards in the recent version. The change in the requirements ensures, that the pytorch version with rocm is installed. 
Also, please change the first step in the [wiki](https://github.com/skier233/nsfw_ai_model_server/wiki/Installation-Instructions-(AMD-Gpu's)):

1. If you use Windows, install WSL, the rocm 7.2 drivers and the WSL usecase, as described in the [official WSL Documentation from AMD](https://rocm.docs.amd.com/projects/radeon-ryzen/en/docs-7.2/docs/install/installrad/wsl/install-radeon.html).

The link in the current wiki is invalid, and we need particular rocm 7.2. Other rocm versions seems to not be compatible with your pytorch versions.
Thank you for your work and help in discord!

